### PR TITLE
fixed typo

### DIFF
--- a/src/MTLFile.js
+++ b/src/MTLFile.js
@@ -257,7 +257,7 @@ class MTLFile {
   // ns 500
   // Defines how focused the specular highlight is,
   // typically in the range of 0 to 1000.
-  _parseNS(lineItems) {
+  _parseNs(lineItems) {
     this._notImplemented('Ns');
   }
 


### PR DESCRIPTION
in main switch 'this._parseNs' is called, but the function was called '_parseNS'