### PR TITLE
added support for 'd' and 'Tr' statements. 

### DIFF
--- a/src/MTLFile.js
+++ b/src/MTLFile.js
@@ -82,6 +82,9 @@ class MTLFile {
         case 'd': // Controls how the current material dissolves (becomes transparent)
           this._parseD(lineItems);
           break;
+        case 'tr': // Controls how the current material becomes transparent (dissolves)
+          this._parseTr(lineItems);
+          break;
         case 'sharpness':
           this._parseSharpness(lineItems);
           break;
@@ -242,7 +245,7 @@ class MTLFile {
       this._fileError('to few arguments, expected: Ka/Kd/Ks keyword followed by: r g b values');
     }
     if (lineItems[1].toLowerCase() == 'spectral') {
-      this._notImplemented('Ka spectral <filename> <factor>');
+      this._notImplemented('Ka spectral <filename> <>');
       return;
     } else if (lineItems[1].toLowerCase() == 'xyz') {
       this._notImplemented('Ka xyz <x> <y> <z>');
@@ -272,10 +275,21 @@ class MTLFile {
   }
 
   // d factor
-  // d -halo factor
   // Controls how much the material dissolves (becomes transparent).
   _parseD(lineItems) {
-    this._notImplemented('d');
+    if (lineItems.length < 2) {
+      this._fileError('to few arguments, expected: d <factor>');
+    }
+    this._getCurrentMaterial().dissolve = parseFloat(lineItems[1]);
+  }
+
+  // Tr factor
+  // Controls how much the material becomes transparent (dissolves).
+  _parseTr(lineItems) {
+    if (lineItems.length < 2) {
+      this._fileError('to few arguments, expected: Tr <float>');
+    }
+    this._getCurrentMaterial().dissolve = 1.0-parseFloat(lineItems[1]);
   }
 
   _parseSharpness(lineItems) {

--- a/src/MTLFile.js
+++ b/src/MTLFile.js
@@ -82,7 +82,7 @@ class MTLFile {
         case 'd': // Controls how the current material dissolves (becomes transparent)
           this._parseD(lineItems);
           break;
-        case 'tr': // Controls how the current material becomes transparent (dissolves)
+        case 'tr': // Controls how transparent the current material is (inverted: Tr = 1 - d)
           this._parseTr(lineItems);
           break;
         case 'sharpness':
@@ -275,7 +275,10 @@ class MTLFile {
   }
 
   // d factor
-  // Controls how much the material dissolves (becomes transparent).
+  // Controls how much the current material dissolves (becomes transparent).
+  // Materials can be transparent. This is referred to as being dissolved. 
+  // Unlike real transparency, the result does not depend upon the thickness of the object. 
+  // A value of 1.0 for "d" is the default and means fully opaque, as does a value of 0.0 for "Tr".
   _parseD(lineItems) {
     if (lineItems.length < 2) {
       this._fileError('to few arguments, expected: d <factor>');
@@ -284,12 +287,15 @@ class MTLFile {
   }
 
   // Tr factor
-  // Controls how much the material becomes transparent (dissolves).
+  // Controls how transparent the current material is (inverted: Tr = 1 - d).
+  // Materials can be transparent. This is referred to as being dissolved. 
+  // Unlike real transparency, the result does not depend upon the thickness of the object. 
+  // A value of 1.0 for "d" is the default and means fully opaque, as does a value of 0.0 for "Tr".
   _parseTr(lineItems) {
     if (lineItems.length < 2) {
       this._fileError('to few arguments, expected: Tr <float>');
     }
-    this._getCurrentMaterial().dissolve = 1.0-parseFloat(lineItems[1]);
+    this._getCurrentMaterial().dissolve = 1.0 - parseFloat(lineItems[1]);
   }
 
   _parseSharpness(lineItems) {

--- a/src/MTLFile.js
+++ b/src/MTLFile.js
@@ -168,7 +168,8 @@ class MTLFile {
       },
       map_d: {
         file: null
-      }
+      },
+      dissolve: 1.0,
     };
     this.materials.push(newMaterial);
   }

--- a/src/MTLFile.js
+++ b/src/MTLFile.js
@@ -293,7 +293,7 @@ class MTLFile {
   // A value of 1.0 for "d" is the default and means fully opaque, as does a value of 0.0 for "Tr".
   _parseTr(lineItems) {
     if (lineItems.length < 2) {
-      this._fileError('to few arguments, expected: Tr <float>');
+      this._fileError('to few arguments, expected: Tr <factor>');
     }
     this._getCurrentMaterial().dissolve = 1.0 - parseFloat(lineItems[1]);
   }

--- a/src/MTLFile.js
+++ b/src/MTLFile.js
@@ -245,7 +245,7 @@ class MTLFile {
       this._fileError('to few arguments, expected: Ka/Kd/Ks keyword followed by: r g b values');
     }
     if (lineItems[1].toLowerCase() == 'spectral') {
-      this._notImplemented('Ka spectral <filename> <>');
+      this._notImplemented('Ka spectral <filename> <factor>');
       return;
     } else if (lineItems[1].toLowerCase() == 'xyz') {
       this._notImplemented('Ka xyz <x> <y> <z>');

--- a/tests/MTLFile.test.js
+++ b/tests/MTLFile.test.js
@@ -63,17 +63,20 @@ describe('MTLFile', () => {
     });
   });
 
-  describe('d Statements', () => {
+  describe('d and Tr Statements', () => {
     it('sets the dissolve value the current material', () => {
       const materials = new MTLFile('d 1.0').parse();
       expect(materials[0].dissolve).toBe(1.0);
     });
-  });
 
-  describe('Tr Statements', () => {
     it('sets the transparency value the current material', () => {
       const materials = new MTLFile('Tr 0.3').parse();
       expect(materials[0].dissolve).toBe(0.7);
+    });
+
+    it('Default value of dissolve should be 1.0', () => {
+      const materials = new MTLFile('ka 0 0 0\n').parse();
+      expect(materials[0].dissolve).toBe(1.0);
     });
   });
 

--- a/tests/MTLFile.test.js
+++ b/tests/MTLFile.test.js
@@ -77,5 +77,4 @@ describe('MTLFile', () => {
     });
   });
 
-
 });

--- a/tests/MTLFile.test.js
+++ b/tests/MTLFile.test.js
@@ -62,4 +62,20 @@ describe('MTLFile', () => {
       });
     });
   });
+
+  describe('d Statements', () => {
+    it('sets the dissolve value the current material', () => {
+      const materials = new MTLFile('d 1.0').parse();
+      expect(materials[0].dissolve).toBe(1.0);
+    });
+  });
+
+  describe('Tr Statements', () => {
+    it('sets the transparency value the current material', () => {
+      const materials = new MTLFile('Tr 0.3').parse();
+      expect(materials[0].dissolve).toBe(0.7);
+    });
+  });
+
+
 });

--- a/tests/MTLFile.test.js
+++ b/tests/MTLFile.test.js
@@ -79,5 +79,4 @@ describe('MTLFile', () => {
       expect(materials[0].dissolve).toBe(1.0);
     });
   });
-
 });


### PR DESCRIPTION
added support for 'd' and 'Tr' statements. Both resolve to a 'dissolve' property of the related material.
added related unit tests [passes].

from https://en.wikipedia.org/wiki/Wavefront_.obj_file :
Materials can be transparent. This is referred to as being dissolved. Unlike real transparency, the result does not depend upon the thickness of the object. A value of 1.0 for "d" is the default and means fully opaque, as does a value of 0.0 for "Tr".

d 0.9                    # some implementations use 'd'
   Tr 0.1                   # others use 'Tr' (inverted: Tr = 1 - d)

Let me know if you need further changes.